### PR TITLE
회원정보 수정 URL에 포함되어 있던 memberId 제거

### DIFF
--- a/src/main/java/com/omvl/omvl/controller/HomeController.java
+++ b/src/main/java/com/omvl/omvl/controller/HomeController.java
@@ -1,5 +1,6 @@
 package com.omvl.omvl.controller;
 
+import jakarta.servlet.http.HttpSession;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 
@@ -10,7 +11,8 @@ public class HomeController {
 	 * 기본창
 	 */
 	@GetMapping("/")
-	public String home() {
+	public String home(HttpSession httpSession) {
+		httpSession.removeAttribute("member");
 		return "home";
 	}
 

--- a/src/main/java/com/omvl/omvl/controller/MemberController.java
+++ b/src/main/java/com/omvl/omvl/controller/MemberController.java
@@ -89,14 +89,15 @@ public class MemberController {
 	}
 
 	//회원수정 페이지로 이동
-	@GetMapping("/{memberId}/edit")
-	public String editForm(@PathVariable("memberId") String memberId) {
+	@GetMapping("/edit")
+	public String editForm() {
 		return "/members/editForm";
 	}
 
 	//회원수정 진행
-	@PostMapping("/{memberId}/edit")
-	public String edit(@PathVariable("memberId") String memberId, @ModelAttribute Member member, HttpSession session) {
+	@PostMapping("/edit")
+	public String edit(@ModelAttribute Member member, HttpSession session) {
+		String memberId = member.getMemberId();
 		Member editMember = memberService.edit(memberId, member);
 		session.removeAttribute("member");
 		session.setAttribute("member", editMember);

--- a/src/main/resources/templates/items/showDetail.html
+++ b/src/main/resources/templates/items/showDetail.html
@@ -99,7 +99,7 @@
           type="button">주문내역</button>
   <div>
     <button class="btn btn-primary btn-sm"
-            th:onclick="|location.href='@{/members/{memberId}/edit(memberId=${session.member.memberId})}'|"
+            th:onclick="|location.href='@{/members/edit}'|"
             type="button">회원정보 수정</button>
     <button class="btn btn-secondary btn-sm"
             th:onclick="|location.href='@{/}'|"

--- a/src/main/resources/templates/items/showItems.html
+++ b/src/main/resources/templates/items/showItems.html
@@ -22,7 +22,7 @@
           type="button">주문내역</button>
   <div>
     <button class="btn btn-primary btn-sm"
-            th:onclick="|location.href='@{/members/{memberId}/edit(memberId=${session.member.memberId})}'|"
+            th:onclick="|location.href='@{/members/edit}'|"
             type="button">회원정보 수정</button>
     <button class="btn btn-secondary btn-sm"
             th:onclick="|location.href='@{/}'|"

--- a/src/main/resources/templates/items/welcome.html
+++ b/src/main/resources/templates/items/welcome.html
@@ -22,7 +22,7 @@
             type="button">주문내역</button>
   <div>
     <button class="btn btn-primary btn-sm"
-            th:onclick="|location.href='@{/members/{memberId}/edit(memberId=${session.member.memberId})}'|"
+            th:onclick="|location.href='@{/members/edit}'|"
             type="button">회원정보 수정</button>
     <button class="btn btn-secondary btn-sm"
             th:onclick="|location.href='@{/}'|"

--- a/src/main/resources/templates/members/items.html
+++ b/src/main/resources/templates/members/items.html
@@ -22,7 +22,7 @@
           type="button">주문내역</button>
   <div>
     <button class="btn btn-primary btn-sm"
-            th:onclick="|location.href='@{/members/{memberId}/edit(memberId=${session.member.memberId})}'|"
+            th:onclick="|location.href='@{/members/edit}'|"
             type="button">회원정보 수정</button>
     <button class="btn btn-secondary btn-sm"
             th:onclick="|location.href='@{/}'|"


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
회원정보 수정 버튼을 누르면 URL에 memberId를 넣은 채로 화면이동을 했습니다. 하지만 로그인 시 session에 member에 대한 데이터를 담기 때문에 굳이 URL에 memberId를 명시하지 않아도 충분하다고 생각하여 URL에 보이던 memberId를 제거했습니다.

<!---- Resolves: #22  -->

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
